### PR TITLE
replace unsafe runtime string copy with safe compile-time assignment

### DIFF
--- a/include/util/mtp_util.h
+++ b/include/util/mtp_util.h
@@ -124,7 +124,6 @@ typedef struct {
 } usb_status_req_t;
 
 void _util_print_error();
-void _util_get_external_path(char *external_path);
 
 #ifdef __cplusplus
 }

--- a/src/entity/mtp_device.c
+++ b/src/entity/mtp_device.c
@@ -329,9 +329,8 @@ static mtp_bool __add_store_to_device(void)
 	mtp_char *storage_path = NULL;
 	mtp_uint32 store_id = 0;
 	file_attr_t attrs = { 0, };
-	char sto_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
+	char sto_path[] = MTP_EXTERNAL_PATH_CHAR;
 
-	_util_get_external_path(sto_path);
 	storage_path = (mtp_char *)sto_path;
 	store_id = MTP_EXTERNAL_STORE_ID;
 

--- a/src/entity/mtp_store.c
+++ b/src/entity/mtp_store.c
@@ -148,11 +148,9 @@ mtp_uint32 _entity_pack_store_info(store_info_t *info, mtp_uchar *buf,
 mtp_uint32 _entity_get_store_id_by_path(const mtp_char *path_name)
 {
 	mtp_uint32 store_id = 0;
-	char ext_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
+	char ext_path[] = MTP_EXTERNAL_PATH_CHAR;
 
 	retv_if(NULL == path_name, FALSE);
-
-	_util_get_external_path(ext_path);
 
 	if (!strncmp(path_name, ext_path,
 				strlen(ext_path))) {

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -354,8 +354,7 @@ void _mtp_init(void)
 	/* External Storage */
 	{
 	/* LCOV_EXCL_START */
-		char ext_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
-		_util_get_external_path(ext_path);
+		char ext_path[] = MTP_EXTERNAL_PATH_CHAR;
 		if (access(ext_path, F_OK) < 0) {
 			if (FALSE == _util_dir_create((const mtp_char *)ext_path, &error)) {
 				ERR("Cannot make directory!! [%s]\n",

--- a/src/mtp_inoti_handler.c
+++ b/src/mtp_inoti_handler.c
@@ -160,8 +160,7 @@ static void __process_object_added_event(mtp_char *fullpath,
 
 	parent_obj = _entity_get_object_from_store_by_path(store, parent_path);
 	if (NULL == parent_obj) {
-		char ext_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
-		_util_get_external_path(ext_path);
+		char ext_path[] = MTP_EXTERNAL_PATH_CHAR;
 
 		if (!g_strcmp0(parent_path, ext_path)) {
 			DBG("parent is the root folder\n");
@@ -494,8 +493,7 @@ static void __remove_recursive_inoti_watch(mtp_char *path)
 
 static void __clean_up_inoti(void *data)
 {
-	char ext_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
-	_util_get_external_path(ext_path);
+	char ext_path[] = MTP_EXTERNAL_PATH_CHAR;
 
 	__remove_recursive_inoti_watch((mtp_char *)ext_path);
 	__destroy_inoti_open_files_list();

--- a/src/util/mtp_support.c
+++ b/src/util/mtp_support.c
@@ -433,11 +433,9 @@ mtp_bool _util_is_path_len_valid(const mtp_char *path)
 	static mtp_bool is_initialized = FALSE;
 	static mtp_uint32 external_store_len = 0;
 
-	char ext_path[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
+	char ext_path[] = MTP_EXTERNAL_PATH_CHAR;
 
 	retv_if(path == NULL, FALSE);
-
-	_util_get_external_path(ext_path);
 
 	if (!is_initialized) {
 		is_initialized = TRUE;

--- a/src/util/mtp_util.c
+++ b/src/util/mtp_util.c
@@ -47,11 +47,4 @@ void _util_print_error()
 	strerror_r(errno, buff, sizeof(buff));
 	ERR("Error: [%d]:[%s]\n", errno, buff);
 }
-
-void _util_get_external_path(char *external_path)
-{
-/* LCOV_EXCL_START */
-	strncpy(external_path, MTP_EXTERNAL_PATH_CHAR, sizeof(MTP_EXTERNAL_PATH_CHAR));
-	external_path[sizeof(MTP_EXTERNAL_PATH_CHAR) - 1] = 0;
-}
 /* LCOV_EXCL_STOP */


### PR DESCRIPTION
strncpy() was using the source as a length check instead of the
destination, making the check void.

Instead, let's simply assign the value at compilation so that the size
is the right one automatically and any issue is immediately reported by
the compiler.