### PR TITLE
Read device-related values from `cmtp-responder.conf`

### DIFF
--- a/cmtp-responder.conf
+++ b/cmtp-responder.conf
@@ -59,3 +59,10 @@ read_file_delay=0
 #
 ### Experimental (End)
 ### Speed related config (End)
+
+usb_device_manufacturer=Collabora
+usb_device_model=DummyModel
+usb_device_version=DUMMY_VERSION
+usb_device_serial=DUMMY_SERIAL
+
+storage_path=/media/card

--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -108,6 +108,14 @@
 
 #define MTP_CONFIG_FILE_PATH		"/etc/cmtp-responder.conf"
 
+/* Standard says that these fields can have variable length,
+ * so I decided to use 32
+ */
+#define USB_DEVICE_MANUFACTURER_LEN	32
+#define USB_DEVICE_VERSION_LEN		32
+#define USB_DEVICE_SERIAL_LEN		32
+#define USB_DEVICE_MODEL_LEN		32
+
 typedef struct {
 	/* Speed related config */
 	int mmap_threshold;	/* Max. 512KB. If requested memory is lesser than this, malloc is used. Otherwise, mmap is used */
@@ -142,6 +150,12 @@ typedef struct {
 
 	/* Vendor Features */
 	/* Features (End) */
+
+	/* USB Device Data */
+	char device_manufacturer[USB_DEVICE_MANUFACTURER_LEN];
+	char device_model[USB_DEVICE_MODEL_LEN];
+	char device_serial[USB_DEVICE_SERIAL_LEN];
+	char device_version[USB_DEVICE_VERSION_LEN];
 
 	bool is_init;
 } mtp_config_t;

--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -157,6 +157,9 @@ typedef struct {
 	char device_serial[USB_DEVICE_SERIAL_LEN];
 	char device_version[USB_DEVICE_VERSION_LEN];
 
+	/* Storage path */
+	char storage_path[MTP_MAX_PATHNAME_SIZE];
+
 	bool is_init;
 } mtp_config_t;
 

--- a/include/util/mtp_util.h
+++ b/include/util/mtp_util.h
@@ -27,10 +27,6 @@ extern "C" {
 #include "mtp_datatype.h"
 #include "mtp_fs.h"
 
-#define MODEL "DUMMY MODEL"
-#define DEVICE_VERSION "devv_DUMMY_VERSION"
-#define SERIAL "DUMMY_SERIAL"
-
 #define DBG(format, args...) FLOGD(format, ##args)
 #define ERR(format, args...) FLOGD(format, ##args)
 #define DBG_SECURE(format, args...) FLOGD(format, ##args)

--- a/src/entity/mtp_device.c
+++ b/src/entity/mtp_device.c
@@ -31,6 +31,7 @@
  */
 static mtp_device_t _g_device = { 0 };
 mtp_device_t *g_device = &_g_device;
+extern mtp_config_t g_conf;
 
 /*
  * STATIC VARIABLES
@@ -146,19 +147,19 @@ void _init_mtp_device(void)
 	_prop_copy_char_to_ptpstring(&(info->vendor_extn_desc), wtemp, WCHAR_TYPE);
 
 	info->manufacturer.num_chars = 0;
-	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, MTP_MANUFACTURER_CHAR);
+	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, g_conf.device_manufacturer);
 	_prop_copy_char_to_ptpstring(&(info->manufacturer), wtemp, WCHAR_TYPE);
 
 	info->model.num_chars = 0;
-	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, MODEL);
+	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, g_conf.device_model);
 	_prop_copy_char_to_ptpstring(&(info->model), wtemp, WCHAR_TYPE);
 
 	info->device_version.num_chars = 0;
-	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, DEVICE_VERSION);
+	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, g_conf.device_version);
 	_prop_copy_char_to_ptpstring(&(info->device_version), wtemp, WCHAR_TYPE);
 
 	info->serial_no.num_chars = 0;
-	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, SERIAL);
+	_util_utf8_to_utf16(wtemp, sizeof(wtemp) / WCHAR_SIZ, g_conf.device_serial);
 	_prop_copy_char_to_ptpstring(&(info->serial_no), wtemp, WCHAR_TYPE);
 }
 

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -82,6 +82,7 @@ static void __read_mtp_conf(void)
 	char buf[256];
 	char *token;
 	char *saveptr = NULL;
+	bool storage_path_is_specified = false;
 
 	g_conf.mmap_threshold = MTP_MMAP_THRESHOLD;
 
@@ -276,12 +277,26 @@ static void __read_mtp_conf(void)
 
 			strncpy(g_conf.device_version, token, USB_DEVICE_VERSION_LEN);
 
+		} else if (strcasecmp(token, "storage_path") == 0) {
+			token = strtok_r(NULL, "=", &saveptr);
+			if (token == NULL)
+				continue;	//	LCOV_EXCL_LINE
+
+			strncpy(g_conf.storage_path, token, MTP_MAX_PATHNAME_SIZE);
+			storage_path_is_specified = true;
+
 		/* LCOV_EXCL_STOP */
 		} else {
 			ERR("Unknown option : %s\n", buf);
 		}
 	}
 	fclose(fp);
+
+	if (!storage_path_is_specified) {
+		strncpy(g_conf.storage_path, MTP_EXTERNAL_PATH_CHAR, sizeof(MTP_EXTERNAL_PATH_CHAR));
+		storage_path_is_specified = true;
+	}
+
 	g_conf.is_init = true;
 
 	__print_mtp_conf();

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -247,6 +247,35 @@ static void __read_mtp_conf(void)
 				continue;	//	LCOV_EXCL_LINE
 
 			g_conf.usb_schedparam = atoi(token);
+
+		} else if (strcasecmp(token, "usb_device_manufacturer") == 0) {
+			token = strtok_r(NULL, "=", &saveptr);
+			if (token == NULL)
+				continue;	//	LCOV_EXCL_LINE
+
+			strncpy(g_conf.device_manufacturer, token, USB_DEVICE_MANUFACTURER_LEN);
+
+		} else if (strcasecmp(token, "usb_device_model") == 0) {
+			token = strtok_r(NULL, "=", &saveptr);
+			if (token == NULL)
+				continue;	//	LCOV_EXCL_LINE
+
+			strncpy(g_conf.device_model, token, USB_DEVICE_MODEL_LEN);
+
+		} else if (strcasecmp(token, "usb_device_serial") == 0) {
+			token = strtok_r(NULL, "=", &saveptr);
+			if (token == NULL)
+				continue;	//	LCOV_EXCL_LINE
+
+			strncpy(g_conf.device_serial, token, USB_DEVICE_SERIAL_LEN);
+
+		} else if (strcasecmp(token, "usb_device_version") == 0) {
+			token = strtok_r(NULL, "=", &saveptr);
+			if (token == NULL)
+				continue;	//	LCOV_EXCL_LINE
+
+			strncpy(g_conf.device_version, token, USB_DEVICE_VERSION_LEN);
+
 		/* LCOV_EXCL_STOP */
 		} else {
 			ERR("Unknown option : %s\n", buf);

--- a/src/util/mtp_fs.c
+++ b/src/util/mtp_fs.c
@@ -33,6 +33,7 @@
 #include "mtp_device.h"
 
 extern mtp_uint32 g_next_obj_handle;
+extern mtp_config_t g_conf;
 
 /*
  * FUNCTIONS
@@ -690,7 +691,7 @@ mtp_bool _util_ifind_next(mtp_char *dir_name, DIR *dirp, dir_entry_t *dir_info)
 mtp_bool _util_get_filesystem_info(mtp_char *storepath,
 	fs_info_t *fs_info)
 {
-	if (!g_strcmp0(storepath, MTP_EXTERNAL_PATH_CHAR)) {
+	if (!g_strcmp0(storepath, g_conf.storage_path)) {
 		struct statfs buf = { 0 };
 		mtp_uint64 avail_size = 0;
 		mtp_uint64 capacity = 0;

--- a/src/util/mtp_util.c
+++ b/src/util/mtp_util.c
@@ -36,6 +36,7 @@
 
 static phone_state_t _g_ph_status = { 0 };
 phone_state_t *g_ph_status = &_g_ph_status;
+extern mtp_config_t g_conf;
 
 /* LCOV_EXCL_START */
 void _util_print_error()
@@ -51,7 +52,9 @@ void _util_print_error()
 void _util_get_external_path(char *external_path)
 {
 /* LCOV_EXCL_START */
-	strncpy(external_path, MTP_EXTERNAL_PATH_CHAR, sizeof(MTP_EXTERNAL_PATH_CHAR));
-	external_path[sizeof(MTP_EXTERNAL_PATH_CHAR) - 1] = 0;
+	strncpy(external_path, g_conf.storage_path,
+			strnlen(g_conf.storage_path, MTP_MAX_PATHNAME_SIZE) + 1);
+
+	external_path[strnlen(g_conf.storage_path, MTP_MAX_PATHNAME_SIZE)] = 0;
 }
 /* LCOV_EXCL_STOP */


### PR DESCRIPTION
This PR makes it easier to customize the following device fields:
1. serial number
2. device model
3. device version
4. manufacturer

And this PR also adds possibility to specify path to the directory to be exported.