### PR TITLE
systemd: Restart cmtp-responder daemon after USB eject

### DIFF
--- a/systemd/functionfs-daemon.service
+++ b/systemd/functionfs-daemon.service
@@ -9,4 +9,4 @@ USBFunctionDescriptors=/etc/cmtp-responder/descs
 USBFunctionStrings=/etc/cmtp-responder/strs
 KillMode=process
 RestartSec=3
-Restart=on-failure
+Restart=always


### PR DESCRIPTION
Otherwise it is impossible to mount again after the fist mount and unmount.